### PR TITLE
fix the appearance of `nan` in the slope parameter during the learning process

### DIFF
--- a/mod/plr.cpp
+++ b/mod/plr.cpp
@@ -68,8 +68,9 @@ GreedyPLR::process(const struct point& pt, bool file) {
         this->state = "need1";
     } else if (this->state.compare("need1") == 0) {
         this->s1 = pt;
-        setup();
-        this->state = "ready";
+        if (setup()) {
+            this->state = "ready";
+        }
     } else if (this->state.compare("ready") == 0) {
         s = process__(pt, file);
     } else {
@@ -80,13 +81,20 @@ GreedyPLR::process(const struct point& pt, bool file) {
     return s;
 }
 
-void
+bool
 GreedyPLR::setup() {
     this->rho_lower = get_line(get_upper_bound(this->s0, this->gamma),
                                get_lower_bound(this->s1, this->gamma));
+    if (!this->rho_lower.LineCheck()) {
+        return false;
+    }
     this->rho_upper = get_line(get_lower_bound(this->s0, this->gamma),
                                get_upper_bound(this->s1, this->gamma));
+    if (!this->rho_upper.LineCheck()) {
+        return false;
+    }
     this->sint = get_intersetction(this->rho_upper, this->rho_lower);
+    return true;
 }
 
 Segment

--- a/mod/plr.h
+++ b/mod/plr.h
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <string>
 #include <vector>
 #include <deque>
@@ -15,6 +16,13 @@ struct point {
 struct line {
     double a;
     double b;
+
+    bool LineCheck() {
+        if (!std::isnan(a) && !std::isnan(b)) {
+            return true;
+        }
+        return false;
+    }
 };
 
 class Segment {
@@ -47,7 +55,7 @@ private:
     struct line rho_upper;
     struct point sint;
 
-    void setup();
+    bool setup();
     Segment current_segment();
     Segment process__(struct point pt, bool file);
 


### PR DESCRIPTION
In bourbon, the greedy plr algorithm is used to learn the index. When we find the first point of a new segment, we always try to use the next point to build this new segment together with it, but in the `setup` function (mod/plr.cpp:84), when we try to construct rho_upper and rho+lower, **if the x values of the two points are the same, the result of `get_slope` will be nan**.

It is very common for two adjacent points to have the same x value, because the `x` is the **user key in sstable**(table/table.cc:314). Because leveldb will not overwrite the key-value pair of the same user key during the insertion process (instead of generating internal keys with different sequence numbers for them), and the keys in the memtable are strictly ordered (the priority is to sort by user key, and the same user key is sorted by sequence number in descending order), so **if they are in the same memtable two key-value pairs with the same user key are inserted, and they are compressed into the same sstable, and nan may appear during the learning process.**

This situation is very common. I used a real-world trace for simulation, and the probability of `get` errors is more than 3%.

I solved this bug by adding additional checks in the `setup` function. If the result obtained by `get_slope` is nan, it means that the two points actually belong to the same key, and they can be regarded as the same point. We should continue to look for a second point that can form a segment.